### PR TITLE
Added port 443 to ES connection

### DIFF
--- a/src/DynamoToES/index.py
+++ b/src/DynamoToES/index.py
@@ -30,7 +30,8 @@ def lambda_handler(event, context):
         http_auth=awsauth,
         use_ssl=True,
         verify_certs=True,
-        connection_class=RequestsHttpConnection
+        connection_class=RequestsHttpConnection,
+        port = 443
     )
 
     print("Cluster info:")


### PR DESCRIPTION
Elasticsearch defaults to port 9200, however, AWS uses the regular web
ports for their instances of ES. Which means, port 80 for http, port 443
for https. I was running into an issue with this while trying to use this
blueprint.